### PR TITLE
Implement depfu PR commenter

### DIFF
--- a/depfu/.gitignore
+++ b/depfu/.gitignore
@@ -1,0 +1,4 @@
+.bundle
+vendor
+config.yml
+.oscrc

--- a/depfu/Dockerfile
+++ b/depfu/Dockerfile
@@ -1,0 +1,17 @@
+FROM opensuse:42.3
+
+# Install ruby rubygems and bundler
+RUN zypper -n install --no-recommends --replacefiles ruby2.4-rubygem-bundler libxml2-devel libxslt-devel make gcc ruby2.4-devel osc vim
+
+WORKDIR /home/bot
+
+# Copy the code
+COPY bot .
+RUN rm -f config/config.yml
+VOLUME config
+
+# Install gem dependencies
+RUN export NOKOGIRI_USE_SYSTEM_LIBRARIES=1; bundle.ruby2.4 install --jobs=3 --retry=3
+
+# Run our bot
+CMD ["ruby.ruby2.4", "runner.rb"]

--- a/depfu/README.md
+++ b/depfu/README.md
@@ -1,0 +1,30 @@
+# Github Labeling Bot
+
+This bot will check for open pull requests in openSUSE/open-build-service project on GitHub and compare the gem update with the following projects on 
+[build.opensuse.org](https://build.opensuse.org)
+
+- OBS:Server:Unstable 
+- devel:languages:ruby:extensions
+- home:factory-auto:branches:devel:languages:ruby:extensions (coolo's bot)
+
+and depending on the version it will comment on the pull request with a:
+
+- Note that package is already up to date
+- Note with command how update the link reference
+- Note with a link to the pending submit request which needs to get accepted
+- Note that there package is not up to date and there is no pending submit request
+
+# Usage
+
+You can just run the bot script by hand using ruby (after setting up all the environment needed):
+
+```
+ruby bot/runner.rb
+```
+
+Setup first a directory with the config.yml file in it and use that dir path for setting the volume in the docker container.
+
+See this example for a one execution container:
+```
+docker run --rm -it -v PATH_TO_CONFIG/config:/home/bot/config chrisbr/depfu-commenter
+```

--- a/depfu/bot/Gemfile
+++ b/depfu/bot/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'octokit'
+gem 'activemodel'
+gem 'nokogiri'

--- a/depfu/bot/Gemfile.lock
+++ b/depfu/bot/Gemfile.lock
@@ -1,0 +1,42 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    concurrent-ruby (1.0.5)
+    faraday (0.14.0)
+      multipart-post (>= 1.2, < 3)
+    i18n (1.0.0)
+      concurrent-ruby (~> 1.0)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    multipart-post (2.0.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    octokit (4.8.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    public_suffix (3.0.2)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activemodel
+  nokogiri
+  octokit
+
+BUNDLED WITH
+   1.16.1

--- a/depfu/bot/config/config.yml.example
+++ b/depfu/bot/config/config.yml.example
@@ -1,0 +1,3 @@
+:credentials:
+  :login: username
+  :password: mypassword

--- a/depfu/bot/lib/depfu.rb
+++ b/depfu/bot/lib/depfu.rb
@@ -1,0 +1,113 @@
+require 'octokit'
+require 'active_model'
+require './lib/open_build_service'
+require './lib/sawyer'
+
+module Depfu
+  class PullRequestBodyParser
+    include ActiveModel::Model
+    attr_accessor :body
+
+    def parse
+      result = []
+      body.each_line do |line|
+        next unless table_line?(line)
+        splitted = line.split('|')
+        if ['updated', 'created'].include?(splitted[1].strip)
+          result << Gem.new(splitted[2].strip, splitted[4].strip)
+        else
+          result << Gem.new(splitted[1].strip, splitted[4].strip)
+        end
+      end
+      result
+    end
+    
+    def table_line?(line)
+      line.start_with?('|') && !line.start_with?('| name') && !line.start_with?('| action') && !line.start_with?('| ---')
+    end
+  end
+  
+  class PullRequest
+    include ActiveModel::Model 
+    attr_accessor :number, :dependencies
+    
+    def self.all(client = Octokit)
+      client.pull_requests('openSUSE/open-build-service').select { |pr| pr.depfu? }.map do |pr|
+        dependencies = PullRequestBodyParser.new(body: pr.body).parse
+        new(number: pr.number, dependencies: dependencies)
+      end
+    end
+  end
+
+  Gem = Struct.new(:name, :version)
+  
+  class PullRequestCommenter
+    include ActiveModel::Model
+    attr_accessor :client
+    
+    def run
+      depfu_pull_requests.each do |pull_request|
+        body = build_comment(pull_request)
+        bot_comment = bot_comment(pull_request.number)
+        if bot_comment
+          update_comment(body, bot_comment)
+        else
+          create_comment(body, pull_request)
+        end
+      end
+    end
+    
+    private
+    
+    def depfu_pull_requests
+      @depfu_pull_requests ||= Depfu::PullRequest.all(client)
+    end
+    
+    def obs_packages
+      @obs_packages ||= OpenBuildService::Package.all('OBS:Server:Unstable')
+    end
+    
+    def devel_ruby_packages
+      @devel_ruby_packages ||= OpenBuildService::Package.all('devel:languages:ruby:extensions')
+    end
+    
+    def factory_auto_packages
+      @factory_auto_packages ||= OpenBuildService::Package.all('home:factory-auto:branches:devel:languages:ruby:extensions')
+    end
+    
+    def build_comment(pull_request)
+      msg = "Result for PR##{pull_request.number}\n"
+      pull_request.dependencies.each do |gem|
+        if obs_packages.any? { |package| package.name.end_with?(gem.name) && package.version == gem.version }
+          msg << "- Package #{gem.name} is already up to date in O:S:U (#{gem.version}).\n"
+        elsif devel_ruby_packages.any? { |package| package.name.end_with?(gem.name) && package.version == gem.version }
+          msg << "- Package #{gem.name} is already up to date in d:l:r:e (#{gem.version}), update link reference with 'osc setlinkrev OBS:Server:Unstable rubygem-#{gem.name}'.\n"
+        elsif factory_auto_packages.any? { |package| package.name.end_with?(gem.name) && package.version == gem.version }
+          submit_request = factory_auto_packages.find { |package| package.name.end_with?(gem.name) && package.version == gem.version }.submit_requests.first
+          msg << "- There is already a submit request for package #{gem.name} (#{gem.version}). "
+          msg << "Please review and accept [#{submit_request.number}](https://build.opensuse.org/request/show/#{submit_request.number}).\n"
+        else
+          msg << "- There is no submit request for #{gem.name} (#{gem.version}).\n"
+          msg << "- If you recently accepted a submit request, the repository is probably not yet published!\n"
+        end
+      end
+      msg
+    end
+    
+    def update_comment(body, comment)
+      puts "Comment ##{comment.id} already exists"
+      return if comment.body == body
+      puts "Comment ##{comment.id} did change, updating..."
+      client.update_comment('openSUSE/open-build-service', comment.id, body)
+    end
+    
+    def create_comment(body, pull_request)
+      puts "No comment, creating new one..."
+      client.add_comment('openSUSE/open-build-service', pull_request.number, body)
+    end
+    
+    def bot_comment(pull_request_number)
+      client.issue_comments('openSUSE/open-build-service', pull_request_number).find { |comment| comment.user.login == client.user.login }
+    end
+  end
+end

--- a/depfu/bot/lib/open_build_service.rb
+++ b/depfu/bot/lib/open_build_service.rb
@@ -1,0 +1,29 @@
+require 'active_model'
+require 'nokogiri'
+
+module OpenBuildService
+  class Package
+    include ActiveModel::Model
+    attr_accessor :project_name, :name, :version
+    
+    def self.all(project)
+      result = `osc -c /home/bot/config/.oscrc api /status/project/#{project}`
+      Nokogiri::XML(result).xpath("//package").map do |package|
+        new(
+          name: package.attribute('name').value.strip,
+          project_name: package.attribute('project').value.strip,
+          version: package.attribute('version').value.strip
+        )
+      end
+    end
+    
+    def submit_requests
+      search = "search/request?match=(state/@name='new')+and+(action/source/@project='#{project_name}')+and+(action/source/@package='#{name}')"
+      result = `osc -c /home/bot/config/.oscrc api "#{search}"`
+      Nokogiri::XML(result).xpath('//request').map do |request|
+        SubmitRequest.new(request.attribute('id').value.strip)
+      end
+    end
+  end
+  SubmitRequest = Struct.new(:number)
+end

--- a/depfu/bot/lib/sawyer.rb
+++ b/depfu/bot/lib/sawyer.rb
@@ -1,0 +1,10 @@
+module Sawyer
+ class Resource
+   # depfu creates a branch in the repository 
+   # e.g. depfu/update/srcapi/rubocop-0.55.0
+   # so we need to check for the head ref name
+   def depfu?
+     key?(:head) && head.key?(:ref) && head.ref.start_with?('depfu') 
+   end
+ end
+end

--- a/depfu/bot/runner.rb
+++ b/depfu/bot/runner.rb
@@ -1,0 +1,7 @@
+require 'octokit'
+require './lib/depfu'
+require 'yaml'
+
+config = YAML.load_file('config/config.yml')
+client = Octokit::Client.new(config[:credentials])
+Depfu::PullRequestCommenter.new(client: client).run


### PR DESCRIPTION
Which checks the status of d:l:r:e and home:factory-auto project for existing packages and submit requests and compares the version with the new version in the pull request. Depending on the result, it will comment on the PR.

Result will look like this:

![image](https://user-images.githubusercontent.com/3799140/38981682-42c524c2-43c0-11e8-82c2-5662547babff.png)

Features:
* Links pending submit requests
* Pastes command to update link reference in O:S:U if package is already up to date in d:l:r:e
* Tells you if there is no submit request and package is not up to date

Note: This is a minimal effort as we want to get rid of the rubygem packages anyway in the near future. Tests showed that it is already working quite good. There could be a problem with packages with the version in the name however (e.g. activerecord_5.1). There is also some delay between accepting a submit request and the repository publishing, in this timeframe the bot will report that there is no submit request (the fallback case).
