### PR TITLE
Fix table parsing of main table

### DIFF
--- a/depfu/bot/lib/depfu.rb
+++ b/depfu/bot/lib/depfu.rb
@@ -14,7 +14,12 @@ module Depfu
         next unless table_line?(line)
         splitted = line.split('|')
         if ['updated', 'created', 'added'].include?(splitted[1].strip)
+          # add the dependencies (second table)
           result << Gem.new(splitted[2].strip, splitted[4].strip)
+        elsif 'removed' != (splitted[1].strip)
+          # everything what is not removed, updated, created or added is the 'main' dependency (first table)
+          # Removed dependencies we skip
+          result << Gem.new(splitted[1].strip, splitted[4].strip)
         end
       end
       result


### PR DESCRIPTION
Introduced in #4.
We skipped the main dependency (first table in the comment of the depfu PR).
Added the else branch again with the addition to skip removed dependencies
because for removed dependencies there is 'nothing' to do.