### PR TITLE
Change the format of the summary shown in the PRs

### DIFF
--- a/pull_request_package/lib/github_status_reporter.rb
+++ b/pull_request_package/lib/github_status_reporter.rb
@@ -12,15 +12,13 @@ class GitHubStatusReporter
   private
 
   def description
-    count = summary[:success] + summary[:failure] + summary[:pending]
-    case state
-    when :failure
-       "#{summary[:failure]}/#{count} failed"
-    when :success
-       "#{count} succeeded"
-    else
-       "#{summary[:pending]}/#{count} building"
-    end
+    count_all = summary[:success] + summary[:failure] + summary[:pending]
+    count_finished = count_all - summary[:pending]
+
+    result = "#{count_finished}/#{count_all} processed"
+    result << " | #{summary[:failure]} failures" if summary[:failure] > 0
+
+    result
   end
 
   def state


### PR DESCRIPTION
Previously the format of the summary would change depending of the state
of the build jobs (building, failed, succeeded). This means that a "3 / 4
building" could at the end of the test run turn into "1 / 4 failed".
Which can be confusing.

With this patch the summary always shows the number of finished build jobs
and the overall job count. In case of build failures a count of failed
builds is shown as well.

The indicator for the overall state of a test run is already covered by
the GitHub status-icon.