### PR TITLE
Remove date restriction

### DIFF
--- a/pull_request_package/runner.rb
+++ b/pull_request_package/runner.rb
@@ -14,7 +14,7 @@ end
 
 new_packages = []
 client.pull_requests('openSUSE/open-build-service').each do |pull_request|
-  next if pull_request.updated_at < (Date.today - 7).to_time || pull_request.base.ref != 'master'
+  next if pull_request.base.ref != 'master'
 
   logger.info('')
   logger.info(line_seperator(pull_request))


### PR DESCRIPTION
This should prevent older pull requests from being checked. We want to check all the pull requests.