### PR TITLE
Reduce number of repositories in OBS CI jobs

### DIFF
--- a/pull_request_package/new_project_template.xml
+++ b/pull_request_package/new_project_template.xml
@@ -10,14 +10,6 @@
   <debuginfo>
     <enable/>
   </debuginfo>
-  <repository name="openSUSE_42.3">
-    <path project="OBS:Server:Unstable" repository="openSUSE_42.3"/>
-    <arch>x86_64</arch>
-  </repository>
-  <repository name="openSUSE_15.0">
-    <path project="OBS:Server:Unstable" repository="openSUSE_15.0"/>
-    <arch>x86_64</arch>
-  </repository>
   <repository name="SLE_15">
     <path project="OBS:Server:Unstable" repository="SLE_15"/>
     <arch>x86_64</arch>


### PR DESCRIPTION
Reducing the number of build targets reduces the likelyness that one
build job delays the waiting time for the CI, e.g. due to test failures
caused by flickering tests or high usage of build machines.
openSUSE 42.3 and SLE3 SP3 as well as openSUSE 15 and SLE15 share
(almost) the same codebase. Hence we drop them.