### PR TITLE
Update new_project_template: use SLE-12-SP4. Disable SLE-12-SP3

### DIFF
--- a/pull_request_package/new_project_template.xml
+++ b/pull_request_package/new_project_template.xml
@@ -14,8 +14,8 @@
     <path project="OBS:Server:Unstable" repository="SLE_15"/>
     <arch>x86_64</arch>
   </repository>
-  <repository name="SLE_12_SP3">
-    <path project="OBS:Server:Unstable" repository="SLE_12_SP3"/>
+  <repository name="SLE_12_SP4">
+    <path project="OBS:Server:Unstable" repository="SLE_12_SP4"/>
     <arch>x86_64</arch>
   </repository>
 </project>


### PR DESCRIPTION
Since yesterday, we are using SLE-12-SP4 in production, therefore, we should build our packages for that, making SLE-12-SP3 obsolete.