### PR TITLE
Dockerize obs-package-bot service

### DIFF
--- a/obs-package-status/Dockerfile
+++ b/obs-package-status/Dockerfile
@@ -1,0 +1,16 @@
+# Leap 15.1
+FROM registry.opensuse.org/home/vpereirabr/dockerimages/containers/obs-tools/base:latest
+
+COPY .  /home/frontend/obs-package-status
+
+RUN chown -R frontend:users /home/frontend/
+
+WORKDIR /home/frontend/obs-package-status
+
+RUN bundler.ruby2.5 install
+
+USER frontend
+
+ENTRYPOINT ["./entrypoint.sh"]
+
+CMD ["./status-check.rb"]

--- a/obs-package-status/Makefile
+++ b/obs-package-status/Makefile
@@ -1,0 +1,7 @@
+build:
+	docker build -t obs-package-status .
+
+run:
+	docker run --restart always -v $(PWD):/home/package-bot/obs-package-status -e RUN_EVERY=600 -d obs-package-status
+
+

--- a/obs-package-status/README.md
+++ b/obs-package-status/README.md
@@ -61,5 +61,9 @@ A list of OBS Repositories you want to check the package for. Separated by blank
 
 ## Usage
 1. Clone the repository
-1. bundle install
-1. bundle exec status-check.rb
+2. Build the docker container:
+``` make build```
+3. Start the service:
+```
+make run
+```

--- a/obs-package-status/entrypoint.sh
+++ b/obs-package-status/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+while true; do
+  exec "$@"
+  sleep $RUN_EVERY
+done


### PR DESCRIPTION
Port obs-package-bot to run in a docker container.

Base image is being built on OBS as suggested by @coolo 
