### PR TITLE
Fix obs package bot systemd files

### DIFF
--- a/pull_request_package/obs-package-bot.service
+++ b/pull_request_package/obs-package-bot.service
@@ -4,8 +4,7 @@ Description=obs-package bot
 [Service]
 User=package-bot
 WorkingDirectory=/home/package-bot/obs-tools/pull_request_package
-Environment="PATH='/home/package-bot/.gem/bin:'$PATH
+Environment="PATH=/home/package-bot/.gem/bin:/usr/bin:$PATH"
 Environment="GEM_HOME=/home/package-bot/.gem"
 Environment="GEM_PATH=/home/package-bot/.gem"
-ExecStart=/home/package-bot/.gem/bin/bundle.ruby2.4 exec /usr/bin/ruby.ruby2.4 runner.rb 
-
+ExecStart=/home/package-bot/.gem/bin/bundle.ruby2.4 exec /usr/bin/ruby.ruby2.4 runner.rb

--- a/pull_request_package/obs-package-bot.timer
+++ b/pull_request_package/obs-package-bot.timer
@@ -1,4 +1,4 @@
-[unit]
+[Unit]
 Description=obs-package-bot timer
 
 [Timer]


### PR DESCRIPTION
We fixed a path assignment in the service file and  changed 'unit' by '**U**nit' in the timer.
In the service file we also added '/usr/bin'. Otherwise osc binary couldn't be found.