### PR TITLE
Move the existing docker compose file for openqa-trigger into the project root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: "2.1"
+version: "2.0"
 services:
   openqa-trigger:
     build:
       dockerfile: Dockerfile
-      context: .
-    command: ./schedule-obs.sh
+      context: openqa-trigger
     restart: always
     environment:
       - RUN_EVERY=600

--- a/openqa-trigger/Dockerfile
+++ b/openqa-trigger/Dockerfile
@@ -9,8 +9,10 @@ RUN chown -R frontend:users /home/frontend/
 
 WORKDIR /home/frontend/openqa-trigger
 
+COPY entrypoint.sh schedule-obs.sh /usr/local/bin/
+
 USER frontend
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-CMD ["./schedule-obs.sh"]
+CMD ["/usr/local/bin/schedule-obs.sh"]


### PR DESCRIPTION
This PR moves the already existing docker compose config file into the project root so we can share it between services and coordinate dependencies there.

Doing so the docker compose config file becomes a common configuration for all tools
