### PR TITLE
Add obs-package-status service to docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,4 +26,4 @@ services:
     environment:
       - RUN_EVERY=600
     volumes:
-      - .:/home/package-bot/obs-package-status
+      - .:/home/frontend/obs-package-status

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,12 @@ services:
       - RUN_EVERY=600
     volumes:
       - .:/home/frontend/openqa-mail-notification
+  obs-package-status:
+    build:
+      dockerfile: Dockerfile
+      context: obs-package-status
+    restart: always
+    environment:
+      - RUN_EVERY=600
+    volumes:
+      - .:/home/package-bot/obs-package-status

--- a/obs-package-status/Dockerfile
+++ b/obs-package-status/Dockerfile
@@ -9,8 +9,11 @@ WORKDIR /home/frontend/obs-package-status
 
 RUN bundler.ruby2.5 install
 
+COPY entrypoint.sh status-check.rb /usr/local/bin/
+RUN chmod a+x /usr/local/bin/entrypoint.sh /usr/local/bin/status-check.rb
+
 USER frontend
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-CMD ["./status-check.rb"]
+CMD ["/usr/local/bin/status-check.rb"]


### PR DESCRIPTION
This PR:
* Adds the `obs-package-status` service to the `docker-compose.yml`.
* Apply known best practices
* Complements https://github.com/openSUSE/obs-tools/pull/37