### PR TITLE
Update repositories to test the builds

### DIFF
--- a/pull_request_package/new_project_template.xml
+++ b/pull_request_package/new_project_template.xml
@@ -10,12 +10,16 @@
   <debuginfo>
     <enable/>
   </debuginfo>
-  <repository name="SLE_15">
-    <path project="OBS:Server:Unstable" repository="SLE_15"/>
+  <repository name="SLE_15_SP2">
+    <path project="OBS:Server:Unstable" repository="SLE_15_SP2"/>
     <arch>x86_64</arch>
   </repository>
-  <repository name="SLE_12_SP4">
-    <path project="OBS:Server:Unstable" repository="SLE_12_SP4"/>
+  <repository name="SLE_15_SP1">
+    <path project="OBS:Server:Unstable" repository="SLE_15_SP1"/>
+    <arch>x86_64</arch>
+  </repository>
+  <repository name="SLE_12_SP5">
+    <path project="OBS:Server:Unstable" repository="SLE_12_SP5"/>
     <arch>x86_64</arch>
   </repository>
 </project>


### PR DESCRIPTION
After upgrading from SLE12 SP4 to SLE15 SP1 in our CI, we don't need
to build obs-server packages for SLE12 SP4.

Apart from that, we also added the SLE12 SP5, SLE15 SP1 and SLE15 SP2.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>