### PR TITLE
Remove branch 2.9 from being tested with openQA

### DIFF
--- a/openqa-mail-notification/config.yml.example
+++ b/openqa-mail-notification/config.yml.example
@@ -7,4 +7,3 @@ distribution: obs
 versions:
   Unstable: '62'
   '2.10': '63'
-  '2.9': '17'

--- a/openqa-trigger/README.md
+++ b/openqa-trigger/README.md
@@ -1,6 +1,6 @@
 # OpenQA Trigger
 This script triggers the openqa tests of OBS (Open Build Service). Currently,
-the tested Appliance versions are: **2.9**, **2.10** and **Unstable**.
+the tested Appliance versions are: **2.10** and **Unstable**.
 
 ## Requirements
 The machine needs to have installed previously `docker`, `docker-compose` and `git`.
@@ -13,4 +13,3 @@ to `client.conf` and add the openqa **host**, API **key** and API **secret**.
 1. Clone the repository
 1. `docker-compose build`
 1. `docker-compose up -d`
-

--- a/openqa-trigger/schedule-obs.sh
+++ b/openqa-trigger/schedule-obs.sh
@@ -16,5 +16,4 @@ function trigger_run {
 }
 
 trigger_run Unstable Server:/Unstable/images
-trigger_run 2.9 Server:/2.9:/Staging/images
 trigger_run 2.10 Server:/2.10:/Staging/images


### PR DESCRIPTION
OBS 2.9 is no longer supported. There is no need to keep testing it with openQA.