### PR TITLE
Remove state from openqa-mail-notification

### DIFF
--- a/openqa-mail-notification/.dockerignore
+++ b/openqa-mail-notification/.dockerignore
@@ -1,4 +1,3 @@
 ./Dockerfile
-./last_builds
 ./README.md
 ./docker-compose.yml

--- a/openqa-mail-notification/.gitignore
+++ b/openqa-mail-notification/.gitignore
@@ -1,3 +1,2 @@
 *.swp
 config.yml
-last_builds/build-*

--- a/openqa-mail-notification/last_builds/README.md
+++ b/openqa-mail-notification/last_builds/README.md
@@ -1,4 +1,0 @@
-This directory will keep the temporary files to store the last
-openQA test run for each branch of OBS.
-
-Don't delete this directory.


### PR DESCRIPTION
We always look at the last build on openQA. Instead of comparing filenames to
the last build we have seen previously (state), we look if the build is older
than the frequency we check (10 minutes). If yes, it's a build we haven't seen.